### PR TITLE
Remove dependency on `importlib_metadata` for Python<=3.8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,6 @@ package_dir =
 # new major versions. This works if the required packages follow Semantic Versioning.
 # For more information, check out https://semver.org/.
 install_requires =
-    importlib-metadata; python_version<"3.8"
     packaging>=20.7
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,10 +59,12 @@ exclude =
 # `pip install ini2toml[PDF]` like:
 # PDF = ReportLab; RXP
 full =
+    importlib-metadata; python_version<"3.8"
     configupdater>=3.0.1,<4
     atoml>=1.1.0,<2
     # atoml @ git+https://github.com/abravalheri/atoml@table-common-ancestor#egg=atoml
 lite =
+    importlib-metadata; python_version<"3.8"
     tomli-w>=0.4.0,<2
 all =
     configupdater>=3.0.1,<4

--- a/src/ini2toml/__init__.py
+++ b/src/ini2toml/__init__.py
@@ -1,10 +1,19 @@
 import sys
 
-if sys.version_info[:2] >= (3, 8):
+if sys.version_info[:2] >= (3, 8):  # pragma: no cover
     # TODO: Import directly (no need for conditional) when `python_requires = >= 3.8`
-    from importlib.metadata import PackageNotFoundError, version  # pragma: no cover
-else:
-    from importlib_metadata import PackageNotFoundError, version  # pragma: no cover
+    from importlib.metadata import PackageNotFoundError, version
+else:  # pragma: no cover
+    try:
+        from importlib_metadata import PackageNotFoundError, version
+    except ImportError:
+        from pkg_resources import DistributionNotFound as PackageNotFoundError
+
+        def version(name):
+            import pkg_resources
+
+            return pkg_resources.get_distribution(name).version
+
 
 try:
     # Change here if project is renamed and does not equal the package name

--- a/src/ini2toml/plugins/__init__.py
+++ b/src/ini2toml/plugins/__init__.py
@@ -9,36 +9,42 @@ from typing import Callable, Iterable, List, Optional
 from .. import __version__
 from ..types import Plugin
 
-if sys.version_info[:2] >= (3, 8):  # pragma: no cover
-    # TODO: Import directly (no need for conditional) when `python_requires = >= 3.8`
-    from importlib.metadata import EntryPoint, entry_points
-else:  # pragma: no cover
-    from importlib_metadata import EntryPoint, entry_points
-
-
 ENTRYPOINT_GROUP = "ini2toml.processing"
 
+try:
+    if sys.version_info[:2] >= (3, 8):  # pragma: no cover
+        # TODO: Import directly (no conditional) when `python_requires = >= 3.8`
+        from importlib.metadata import EntryPoint, entry_points
+    else:  # pragma: no cover
+        from importlib_metadata import EntryPoint, entry_points
 
-def iterate_entry_points(group=ENTRYPOINT_GROUP) -> Iterable[EntryPoint]:
-    """Produces a generator yielding an EntryPoint object for each plugin registered
-    via `setuptools`_ entry point mechanism.
+    def iterate_entry_points(group=ENTRYPOINT_GROUP) -> Iterable[EntryPoint]:
+        """Produces a generator yielding an EntryPoint object for each plugin registered
+        via `setuptools`_ entry point mechanism.
 
-    This method can be used in conjunction with :obj:`load_from_entry_point` to filter
-    the plugins before actually loading them.
+        This method can be used in conjunction with :obj:`load_from_entry_point` to
+        filter the plugins before actually loading them.
 
 
-    .. _setuptools: https://setuptools.pypa.io/en/latest/userguide/entry_point.html
-    """  # noqa
-    entries = entry_points()
-    if hasattr(entries, "select"):
-        # The select method was introduced in importlib_metadata 3.9 (and Python 3.10)
-        # and the previous dict interface was declared deprecated
-        entries_ = entries.select(group=group)  # type: ignore
-    else:
-        # TODO: Once Python 3.10 becomes the oldest version supported, this fallback and
-        #       conditional statement can be removed.
-        entries_ = (plugin for plugin in entries.get(group, []))
-    return sorted(entries_, key=lambda e: e.name)
+        .. _setuptools: https://setuptools.pypa.io/en/latest/userguide/entry_point.html
+        """  # noqa
+        entries = entry_points()
+        if hasattr(entries, "select"):
+            # The select method was introduced in importlib_metadata 3.9/3.10
+            # and the previous dict interface was declared deprecated
+            entries_ = entries.select(group=group)  # type: ignore
+        else:
+            # TODO: Once Python 3.10 becomes the oldest version supported, this fallback
+            #       and conditional statement can be removed.
+            entries_ = (plugin for plugin in entries.get(group, []))
+        return sorted(entries_, key=lambda e: e.name)
+
+
+except ImportError:  # pragma: no cover
+    from pkg_resources import EntryPoint, iter_entry_points  # type: ignore
+
+    def iterate_entry_points(group=ENTRYPOINT_GROUP) -> Iterable[EntryPoint]:
+        return iter_entry_points(group)
 
 
 def load_from_entry_point(entry_point: EntryPoint) -> Plugin:

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -2,12 +2,11 @@
 # published under the MIT license.
 # The original PyScaffold license can be found in 'tests/examples/pyscaffold'
 
-import sys
 
 import pytest
 
 from ini2toml import plugins
-from ini2toml.plugins import ENTRYPOINT_GROUP, ErrorLoadingPlugin
+from ini2toml.plugins import ENTRYPOINT_GROUP, EntryPoint, ErrorLoadingPlugin
 
 EXISTING = (
     "setuptools_pep621",
@@ -18,13 +17,6 @@ EXISTING = (
     "mypy",
     "independent_tasks",
 )
-
-
-if sys.version_info[:2] >= (3, 8):
-    # TODO: Import directly (no need for conditional) when `python_requires = >= 3.8`
-    from importlib.metadata import EntryPoint  # pragma: no cover
-else:
-    from importlib_metadata import EntryPoint  # pragma: no cover
 
 
 def test_load_from_entry_point__error():


### PR DESCRIPTION
… by relying on pkg_resources instead