### PR TITLE
Replace `atoml` with `tomlkit`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -125,5 +125,5 @@ For details and usage information on PyScaffold see https://pyscaffold.org/.
 .. _pipx: https://pypa.github.io/pipx/
 .. _project dependency: https://packaging.python.org/tutorials/managing-dependencies/
 .. _TOML: https://toml.io/en/
-.. _TOML library: https://github.com/frostming/atoml
+.. _TOML library: https://github.com/sdispater/tomlkit
 .. _virtual environment: https://realpython.com/python-virtual-environments-a-primer/

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,14 +62,14 @@ exclude =
 full =
     importlib-metadata; python_version<"3.8"
     configupdater>=3.0.1,<4
-    atoml>=1.1.1,<2
+    tomlkit>=0.9.2,<2
     # atoml @ git+https://github.com/abravalheri/atoml@table-common-ancestor#egg=atoml
 lite =
     importlib-metadata; python_version<"3.8"
     tomli-w>=0.4.0,<2
 all =
     configupdater>=3.0.1,<4
-    atoml>=1.1.1,<2
+    tomlkit>=0.9.2,<2
     # atoml @ git+https://github.com/abravalheri/atoml@table-common-ancestor#egg=atoml
     tomli-w>=0.4.0,<2
 

--- a/src/ini2toml/drivers/full_toml.py
+++ b/src/ini2toml/drivers/full_toml.py
@@ -1,5 +1,5 @@
 """This module serves as a compatibility layer between API-compatible
-style preserving TOML editing libraries (e.g. atoml and atoml).
+style preserving TOML editing libraries (e.g. tomlkit and atoml).
 It makes it easy to swap between implementations for testing (by means of search and
 replace).
 """
@@ -8,7 +8,7 @@ from collections.abc import Mapping, MutableSequence, Sequence
 from functools import singledispatch
 from typing import Iterable, Optional, Tuple, TypeVar, Union, cast
 
-from atoml import (
+from tomlkit import (
     aot,
     array,
     comment,
@@ -20,8 +20,8 @@ from atoml import (
     nl,
     table,
 )
-from atoml.items import AoT, Array, InlineTable, Item, Table
-from atoml.toml_document import TOMLDocument
+from tomlkit.items import AoT, Array, InlineTable, Item, Table
+from tomlkit.toml_document import TOMLDocument
 
 from ..errors import InvalidTOMLKey
 from ..types import (
@@ -127,7 +127,7 @@ def _collapse_commented_kv(
         if k:
             out[k].comment(entry.comment)
         else:
-            out.append(None, comment(entry.comment))
+            out.add(comment(entry.comment))
     return out
 
 
@@ -186,11 +186,10 @@ def _convert_irepr_to_toml(irepr: IntermediateRepr, out: T) -> T:
     if irepr.inline_comment and isinstance(out, Item):
         out.comment(irepr.inline_comment)
     for key, value in irepr.items():
-        # TODO: prefer `add` once atoml's InlineTable supports it
         if isinstance(key, WhitespaceKey):
-            out.append(None, nl())
+            out.add(nl())
         elif isinstance(key, CommentKey):
-            out.append(None, comment(value))
+            out.add(comment(value))
         elif isinstance(key, tuple):
             parent_key, *rest = key
             if not isinstance(parent_key, str):

--- a/src/ini2toml/drivers/lite_toml.py
+++ b/src/ini2toml/drivers/lite_toml.py
@@ -1,5 +1,5 @@
 """This module serves as a compatibility layer between API-compatible
-style preserving TOML editing libraries (e.g. atoml and atoml).
+TOML parsers/serialisers.
 It makes it easy to swap between implementations for testing (by means of search and
 replace).
 """

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -94,7 +94,7 @@ def test_examples_cli(original, expected, capsys):
 
 
 def remove_flake8_from_toml(text: str) -> str:
-    # full_toml uses atoml that should not change any formatting, just remove the
+    # full_toml should not change any formatting, just remove the
     # parts we don't want
     doc = full_toml.loads(text)
     tool = doc.get("tool", {})


### PR DESCRIPTION
Recently the author of `atoml` has became a maintainer of `tomlkit`, and all the advances of `atoml` were backported.

See https://github.com/frostming/atoml/issues/44

This commit returns `tomlkit` as the style-preserving library for `ini2toml`.

Closes #23. 