### PR TITLE
Ensure terminating newline at the end of the file.

### DIFF
--- a/src/ini2toml/plugins/profile_independent_tasks.py
+++ b/src/ini2toml/plugins/profile_independent_tasks.py
@@ -39,4 +39,8 @@ def normalise_newlines(text: str) -> str:
 
 def remove_empty_table_headers(text: str) -> str:
     """Remove empty TOML table headers"""
-    return EMPTY_TABLES.sub(r"[\2]", text).strip()
+    prev_text = ""
+    while text != prev_text:
+        prev_text = text
+        text = EMPTY_TABLES.sub(r"[\2]", text).strip()
+    return text

--- a/tests/plugins/test_profile_independent_tasks.py
+++ b/tests/plugins/test_profile_independent_tasks.py
@@ -1,0 +1,31 @@
+from inspect import cleandoc
+
+from ini2toml.plugins.profile_independent_tasks import (
+    normalise_newlines,
+    remove_empty_table_headers,
+)
+
+
+def test_terminating_line():
+    assert normalise_newlines("a") == "a\n"
+    assert normalise_newlines("a\n") == "a\n"
+    assert normalise_newlines("a\n\n") == "a\n"
+
+
+def test_remove_empty_table_headers():
+    text = """
+    [tools]
+    [tools.setuptools]
+
+    [tools.setuptools.package]
+
+
+    [tools.setuptools.package.find]
+    where = "src"
+    """
+    expected = """
+    [tools.setuptools.package.find]
+    where = "src"
+    """
+
+    assert remove_empty_table_headers(cleandoc(text)) == cleandoc(expected)


### PR DESCRIPTION
POSIX tools expects all lines in text files to end in a newline:

https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_206

This means that it is necessary to have a newline at the end of the `pyproject.toml` file so it can interoperate well with other tools.