### PR TITLE
Fix problems with `EntryPoint` checks in tests

### DIFF
--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -28,11 +28,15 @@ def test_load_from_entry_point__error():
         plugins.load_from_entry_point(fake)
 
 
+def is_entry_point(ep):
+    return all(hasattr(ep, attr) for attr in ("name", "load"))
+
+
 def test_iterate_entry_points():
     plugin_iter = plugins.iterate_entry_points()
     assert hasattr(plugin_iter, "__iter__")
     pluging_list = list(plugin_iter)
-    assert all([isinstance(e, EntryPoint) for e in pluging_list])
+    assert all([is_entry_point(e) for e in pluging_list])
     name_list = [e.name for e in pluging_list]
     for ext in EXISTING:
         assert ext in name_list


### PR DESCRIPTION
These problems were first identified in https://github.com/abravalheri/ini2toml/pull/28/checks?check_run_id=5366834267.