### PR TITLE
Add GH Actions for automatic test and release of tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,110 @@
+name: tests
+
+on:
+  push:
+    # Avoid using all the resources/limits available by checking only
+    # relevant branches and tags. Other branches can be checked via PRs.
+    # branches: [main]
+    tags: ['v*']  # Push events to matching v*, i.e. v1.0, v20.15.10
+  # pull_request:  # Run in every PR
+  workflow_dispatch:  # Allow manually triggering the workflow
+  schedule:
+    # Run roughly every 15 days at 00:00 UTC
+    # (useful to check if updates on dependencies break the package)
+    - cron: '0 0 1,16 * *'
+
+concurrency:
+  group: >-
+    ${{ github.workflow }}-${{ github.ref_type }}-
+    ${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      wheel-distribution: ${{ steps.wheel-distribution.outputs.path }}
+    steps:
+      - uses: actions/checkout@v2
+        with: {fetch-depth: 0}  # deep clone for setuptools-scm
+      - uses: actions/setup-python@v2
+        with: {python-version: "3.10"}
+      - name: Lint code
+        run: pipx run tox -e lint
+      - name: Build package distribution files
+        run: pipx run tox -e clean,build
+      - name: Record the path of wheel distribution
+        id: wheel-distribution
+        run: echo "::set-output name=path::$(ls dist/*.whl)"
+      - name: Store the distribution files for use in other stages
+        # `tests` and `publish` will use the same pre-built distributions,
+        # so we make sure to release the exact same package that was tested
+        uses: actions/upload-artifact@v2
+        with:
+          name: python-distribution-files
+          path: dist/
+          retention-days: 1
+
+  test:
+    needs: prepare
+    strategy:
+      matrix:
+        python:
+        - 3.7  # oldest Python supported by PSF
+        - "3.10"  # newest Python that is stable
+        platform:
+        - ubuntu-latest
+        - macos-latest
+        - windows-latest
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Retrieve pre-built distribution files
+        uses: actions/download-artifact@v2
+        with: {name: python-distribution-files, path: dist/}
+      - name: Run tests
+        run: >-
+          pipx run tox
+          --installpkg '${{ needs.prepare.outputs.wheel-distribution }}'
+          -- -rFEx --durations 10 --color yes
+      - name: Generate coverage report
+        run: pipx run coverage lcov -o coverage.lcov
+      - name: Upload partial coverage report
+        uses: coverallsapp/github-action@master
+        with:
+          path-to-lcov: coverage.lcov
+          github-token: ${{ secrets.github_token }}
+          flag-name: ${{ matrix.platform }} - py${{ matrix.python }}
+          parallel: true
+
+  finalize:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Finalize coverage report
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true
+
+  publish:
+    needs: finalize
+    if: ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with: {python-version: "3.10"}
+      - name: Retrieve pre-built distribution files
+        uses: actions/download-artifact@v2
+        with: {name: python-distribution-files, path: dist/}
+      - name: Publish Package
+        env:
+          # See: https://pypi.org/help/#apitoken
+          TWINE_REPOSITORY: pypi
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: pipx run tox -e publish

--- a/tox.ini
+++ b/tox.ini
@@ -15,13 +15,24 @@ setenv =
 passenv =
     HOME
 extras =
-    testing
     all
+    testing
 # Overwrite dependency just while the latest version is not published:
 # deps =
 #    validate-pyproject @ git+https://github.com/abravalheri/validate-pyproject@main#egg=validate-pyproject
 commands =
     pytest {posargs}
+
+
+[testenv:lint]
+description = Perform static analysis and style checks
+skip_install = True
+deps = pre-commit
+passenv =
+    HOMEPATH
+    PROGRAMDATA
+commands =
+    pre-commit run --all-files {posargs:--show-diff-on-failure}
 
 
 [testenv:typecheck]
@@ -30,10 +41,10 @@ changedir = {toxinidir}
 passenv =
     TERM
     # ^ ensure colors
-deps =
-    mypy
 extras =
     typechecking
+deps =
+    mypy
 commands =
     python -m mypy {posargs:src}
 
@@ -42,17 +53,15 @@ commands =
 description =
     build: Build the package in isolation according to PEP517, see https://github.com/pypa/build
     clean: Remove old distribution files and temporary build artifacts (./build and ./dist)
-# NOTE: build is still experimental, please refer to the links for updates/issues
 # https://setuptools.pypa.io/en/stable/build_meta.html#how-to-use-it
-# https://github.com/pypa/pep517/issues/91
 skip_install = True
 changedir = {toxinidir}
 deps =
     build: build[virtualenv]
 commands =
-    clean: python -c 'from shutil import rmtree; rmtree("build", True); rmtree("dist", True)'
+    clean: python -c 'import shutil; [shutil.rmtree(p, True) for p in ("build", "dist", "docs/_build")]'
+    clean: python -c 'import pathlib, shutil; [shutil.rmtree(p, True) for p in pathlib.Path("src").glob("*.egg-info")]'
     build: python -m build {posargs}
-# By default `build` produces wheels, you can also explicitly use the flags `--sdist` and `--wheel`
 
 
 [testenv:{docs,doctests,linkcheck}]
@@ -87,4 +96,4 @@ passenv =
 deps = twine
 commands =
     python -m twine check dist/*
-    python -m twine upload {posargs:--repository testpypi} dist/*
+    python -m twine upload {posargs:--repository {env:TWINE_REPOSITORY:testpypi}} dist/*


### PR DESCRIPTION
For the sake of minimizing resource utilization, gh-actions are only activated when pushing release tags.