### PR TITLE
Make sure terminating newline is not lost in post-processing

### DIFF
--- a/src/ini2toml/drivers/full_toml.py
+++ b/src/ini2toml/drivers/full_toml.py
@@ -51,7 +51,8 @@ LONG = 120
 
 
 def convert(irepr: IntermediateRepr) -> str:
-    return dumps(collapse(irepr, root=True))
+    text = dumps(collapse(irepr, root=True))
+    return text.strip() + "\n"  # ensure terminating newline (POSIX requirement)
 
 
 @singledispatch

--- a/src/ini2toml/drivers/lite_toml.py
+++ b/src/ini2toml/drivers/lite_toml.py
@@ -18,4 +18,5 @@ __all__ = [
 
 
 def convert(irepr: IntermediateRepr) -> str:
-    return dumps(plain_builtins.convert(irepr))
+    text = dumps(plain_builtins.convert(irepr))
+    return text.strip() + "\n"  # ensure terminating newline (POSIX requirement)

--- a/src/ini2toml/plugins/profile_independent_tasks.py
+++ b/src/ini2toml/plugins/profile_independent_tasks.py
@@ -14,7 +14,11 @@ MISSING_TERMINATING_LINE = re.compile(r"(?<!\n)\Z", re.M)
 
 
 def activate(translator: Translator):
-    tasks = [normalise_newlines, remove_empty_table_headers]
+    tasks = [
+        normalise_newlines,
+        remove_empty_table_headers,
+        ensure_terminating_newlines,
+    ]
     for task in tasks:
         translator.augment_profiles(post_process(task), active_by_default=True)
 
@@ -44,3 +48,7 @@ def remove_empty_table_headers(text: str) -> str:
         prev_text = text
         text = EMPTY_TABLES.sub(r"[\2]", text).strip()
     return text
+
+
+def ensure_terminating_newlines(text: str) -> str:
+    return text.strip() + "\n"

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -41,9 +41,15 @@ def test_examples_api(original, expected, validate):
     translator = Translator()
     available_profiles = list(translator.profiles.keys())
     profile = cli.guess_profile(None, original, available_profiles)
-    out = translator.translate(Path(original).read_text(), profile).strip()
-    expected_text = Path(expected).read_text().strip()
+    orig = Path(original)
+
+    # Make sure file ends in a newline (requirement for posix text files)
+    out = translator.translate(orig.read_text(encoding="utf-8"), profile)
+    assert out.endswith("\n")
+
+    expected_text = Path(expected).read_text(encoding="utf-8")
     assert out == expected_text
+
     # Make sure they can be parsed
     dict_equivalent = tomli.loads(out)
     assert dict_equivalent == tomli.loads(expected_text)
@@ -64,8 +70,13 @@ def test_examples_api_lite(original, expected, validate):
     # We cannot compare "flake8" sections (currently not handled)
     # (ConfigParser automatically strips comments, contrary to ConfigUpdater)
     orig = Path(original)
-    out = remove_flake8_from_toml(translator.translate(orig.read_text(), profile))
-    expected_text = remove_flake8_from_toml(Path(expected).read_text().strip())
+
+    # Make sure file ends in a newline (requirement for posix text files)
+    translated = translator.translate(orig.read_text(encoding="utf-8"), profile)
+    assert translated.endswith("\n")
+
+    out = remove_flake8_from_toml(translated)
+    expected_text = remove_flake8_from_toml(Path(expected).read_text(encoding="utf-8"))
 
     # At least the Python-equivalents should be the same when parsing
     dict_equivalent = tomli.loads(out)
@@ -87,8 +98,13 @@ def test_examples_api_lite(original, expected, validate):
 def test_examples_cli(original, expected, capsys):
     cli.run([original])
     (out, err) = capsys.readouterr()
-    expected_text = Path(expected).read_text().strip()
-    assert out.strip() == expected_text
+
+    # Make sure file ends in a newline (requirement for posix text files)
+    assert out.endswith("\n")
+
+    expected_text = Path(expected).read_text(encoding="utf-8")
+    assert out == expected_text
+
     # Make sure they can be parsed
     assert tomli.loads(out) == tomli.loads(expected_text)
 


### PR DESCRIPTION
Although #27 fixed the problem with the missing newline in some parts of the code... It seems that it is getting lost any way during post processing.

This is another attempt to make sure the terminating newline is not lost.