### PR TITLE
No need to consider `license-files` when handling PEP 621 metadata for setuptools plugin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+Version 0.10
+============
+
+* ``setuptools`` plugin:
+   * Separate the handling of ``license-files`` and PEP 621 metadata, #34
+   * ``license`` and ``license-files`` are no longer added to ``tool.setuptools.dynamic``.
+      Instead ``license-files`` is added directly to ``tool.setuptools``, and the ``license`` should be added as ``project.license.text``.
+
 Version 0.9
 ===========
 

--- a/docs/setuptools_pep621.rst
+++ b/docs/setuptools_pep621.rst
@@ -30,7 +30,7 @@ proposed by ``ini2toml`` takes the following assumptions:
 - ``[options.*]`` sections in ``setup.cfg`` are translated to sub-tables of
   ``[tool.setuptools]`` in ``pyproject.toml``. For example::
 
-    [options.package_data] => [tool.setuptools.package_data]
+    [options.package_data] => [tool.setuptools.package-data]
 
 - Field and subtables in ``[tool.setuptools]`` have the ``_`` character
   replaced by ``-`` in their keys, to follow the conventions set in :pep:`517`
@@ -41,10 +41,10 @@ proposed by ``ini2toml`` takes the following assumptions:
 
     'file: description.rst' => {file = "description.rst"}
 
-  Notice, however, that these directives are not allowed to be used directly
+  Note, however, that these directives are not allowed to be used directly
   under the ``project`` table. Instead, ``ini2toml`` will rely on ``dynamic``,
   as explained bellow.
-  Also note that for some fields (e.g. ``readme`` or ``license``), ``ini2toml``
+  Also note that for some fields (e.g. ``readme``), ``ini2toml``
   might try to automatically convert the directive into values accepted by
   :pep:`621` (for complex scenarios ``dynamic`` might still be used).
 
@@ -120,8 +120,18 @@ proposed by ``ini2toml`` takes the following assumptions:
   :pypi:`setuptools` maintainers decide so. This eventual change is mentioned
   by some members of the community as a nice quality of life improvement.
 
+- The ``metadata.license_files`` field in ``setup.cfg`` is not translated to
+  ``project.license.file`` in ``pyproject.toml``, even when a single file is
+  given.  The reason behind this choice is that ``project.license.file`` is
+  meant to be used in a different way than ``metadata.license_files`` when
+  generating `core metadata`_ (the first is read and expanded into the
+  ``License`` core metadata field, the second is added as a path - relative to
+  the project root - as the ``License-file`` core metadata field). This might
+  change in the future if :pep:`639` is accepted.  Meanwhile,
+  ``metadata.license_files`` is translated to ``tool.setuptools.license-files``.
 
-Please notice these conventions are part of a proposal and will probably
+
+Please note these conventions are part of a proposal and will probably
 change as soon as a pattern is established by the :pypi:`setuptools` project.
 The implementation in ``ini2toml`` is flexible to quickly adapt to these
 changes.
@@ -130,3 +140,4 @@ changes.
 .. _TOML: https://toml.io/en/
 .. _setuptools own configuration file: https://setuptools.pypa.io/en/latest/userguide/declarative_config.html
 .. _entry-points file: https://packaging.python.org/en/latest/specifications/entry-points/
+.. _core metadata: https://packaging.python.org/en/latest/specifications/core-metadata/

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,7 +81,7 @@ testing =
     tomli
     pytest
     pytest-cov
-    validate-pyproject>=0.3.2,<2
+    validate-pyproject>=0.6,<2
 
 typechecking =
     typing-extensions; python_version<"3.8"

--- a/src/ini2toml/drivers/full_toml.py
+++ b/src/ini2toml/drivers/full_toml.py
@@ -105,7 +105,7 @@ def _collapse_commented_kv(
     len_key = len(_key)
     _as_dict = obj.as_dict()
 
-    comments = list(obj._all_comments())
+    comments = list(obj._iter_comments())
     len_comments = sum(len(c) for c in comments) + 4
     # ^-- extra 4 for `  # `
 
@@ -217,6 +217,9 @@ def _convert_irepr_to_toml(irepr: IntermediateRepr, out: T) -> T:
                 ):
                     child = out.setdefault(parent_key, inline_table())
                     child[nested_key] = collapsed_value
+                    cmt = list(getattr(value, "_iter_comments", lambda: [])())
+                    if cmt:
+                        child.comment(" ".join(cmt))
                     continue
             else:
                 nested_key = tuple(rest)

--- a/src/ini2toml/intermediate_repr.py
+++ b/src/ini2toml/intermediate_repr.py
@@ -217,6 +217,10 @@ class Commented(Generic[T]):
     def __repr__(self):
         return f"{self.__class__.__name__}({self.value!r}, {self.comment!r})"
 
+    def _iter_comments(self) -> Iterable[str]:
+        if self.comment:
+            yield self.comment
+
 
 class CommentedList(Generic[T], UserList):
     def __init__(self, data: Sequence[Commented[List[T]]] = ()):
@@ -234,6 +238,11 @@ class CommentedList(Generic[T], UserList):
         values = list(values)
         if values or comment:
             self.insert(i, Commented(values, comment))
+
+    def _iter_comments(self) -> Iterable[str]:
+        for entry in self:
+            if entry.has_comment():
+                yield entry.comment
 
 
 class CommentedKV(Generic[T], UserList):
@@ -261,10 +270,7 @@ class CommentedKV(Generic[T], UserList):
                 out[k] = v
         return out
 
-    def _all_comments(self) -> Iterable[str]:
-        for entry in self:
-            if entry.has_comment():
-                yield entry.comment
+    _iter_comments = CommentedList._iter_comments
 
     def to_ir(self) -> IntermediateRepr:
         """:class:`CommentedKV` are usually intended to represent INI options, while

--- a/src/ini2toml/intermediate_repr.py
+++ b/src/ini2toml/intermediate_repr.py
@@ -239,10 +239,8 @@ class CommentedList(Generic[T], UserList):
         if values or comment:
             self.insert(i, Commented(values, comment))
 
-    def _iter_comments(self) -> Iterable[str]:
-        for entry in self:
-            if entry.has_comment():
-                yield entry.comment
+    def _iter_comments(self: Iterable[Commented]) -> Iterable[str]:
+        return chain.from_iterable(entry._iter_comments() for entry in self)
 
 
 class CommentedKV(Generic[T], UserList):

--- a/tests/examples/django/pyproject.toml
+++ b/tests/examples/django/pyproject.toml
@@ -7,6 +7,7 @@ name = "Django"
 authors = [{name = "Django Software Foundation", email = "foundation@djangoproject.com"}]
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 readme = "README.rst"
+license = {text = "BSD-3-Clause"}
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
     "Environment :: Web Environment",
@@ -25,7 +26,6 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Application Frameworks",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-dynamic = ["license", "version"]
 requires-python = ">=3.8"
 dependencies = [
     "asgiref >= 3.3.2",
@@ -33,6 +33,7 @@ dependencies = [
     "sqlparse >= 0.2.2",
     "tzdata; sys_platform == 'win32'",
 ]
+dynamic = ["version"]
 
 [project.urls]
 Homepage = "https://www.djangoproject.com/"
@@ -57,8 +58,6 @@ zip-safe = false
 find = {namespaces = false}
 
 [tool.setuptools.dynamic]
-license = "BSD-3-Clause"
-license-files = ["LICEN[CS]E*", "COPYING*", "NOTICE*", "AUTHORS*"]
 version = {attr = "django.__version__"}
 
 [tool.distutils.bdist_rpm]

--- a/tests/examples/flask/pyproject.toml
+++ b/tests/examples/flask/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "Flask"
+license = {text = "BSD-3-Clause"}
 authors = [{name = "Armin Ronacher", email = "armin.ronacher@active-4.com"}]
 maintainers = [{name = "Pallets", email = "contact@palletsprojects.com"}]
 description = "A simple framework for building complex web applications."
@@ -20,8 +21,8 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP :: WSGI :: Application",
     "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
-dynamic = ["license", "version"]
 requires-python = ">= 3.6"
+dynamic = ["version"]
 
 [project.urls]
 Homepage = "https://palletsprojects.com/p/flask"
@@ -50,8 +51,6 @@ where = ["src"]
 namespaces = false
 
 [tool.setuptools.dynamic]
-license = "BSD-3-Clause"
-license-files = ["LICEN[CS]E*", "COPYING*", "NOTICE*", "AUTHORS*"]
 version = {attr = "flask.__version__"}
 
 [tool.pytest.ini_options]

--- a/tests/examples/pandas/pyproject.toml
+++ b/tests/examples/pandas/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "pandas"
 description = "Powerful data structures for data analysis, time series, and statistics"
 authors = [{name = "The Pandas Development Team", email = "pandas-dev@python.org"}]
+license = {text = "BSD-3-Clause"}
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
@@ -20,13 +21,13 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Topic :: Scientific/Engineering",
 ]
-dynamic = ["license", "version"]
 requires-python = ">=3.8"
 dependencies = [
     "numpy>=1.18.5",
     "python-dateutil>=2.8.1",
     "pytz>=2020.1",
 ]
+dynamic = ["version"]
 
 [project.readme]
 file = "README.md"
@@ -52,6 +53,7 @@ test = [
 include-package-data = true
 zip-safe = false
 platforms = ["any"]
+license-files = ["LICENSE"]
 
 [tool.setuptools.package-data]
 "*" = ["templates/*", "_libs/**/*.dll"]
@@ -62,10 +64,6 @@ include = ["pandas", "pandas.*"]
 # re-run 'versioneer.py setup' after changing this section, and commit the
 # resulting files.
 namespaces = false
-
-[tool.setuptools.dynamic]
-license = "BSD-3-Clause"
-license-files = ["LICENSE"]
 
 [tool.distutils.build_ext]
 inplace = true

--- a/tests/examples/pluggy/pyproject.toml
+++ b/tests/examples/pluggy/pyproject.toml
@@ -8,6 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pluggy"
 description = "plugin and hook calling mechanisms for python"
+license = {text = "MIT"}
 authors = [{name = "Holger Krekel", email = "holger@merlinux.eu"}]
 classifiers = [
     "Development Status :: 6 - Mature",
@@ -30,9 +31,9 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
 ]
 urls = {Homepage = "https://github.com/pytest-dev/pluggy"}
-dynamic = ["license", "version"]
 requires-python = ">=3.6"
 dependencies = ['importlib-metadata>=0.12;python_version<"3.8"']
+dynamic = ["version"]
 
 [project.readme]
 file = "README.rst"
@@ -53,10 +54,6 @@ packages = ["pluggy"]
 package-dir = {"" = "src"}
 platforms = ["unix", "linux", "osx", "win32"]
 include-package-data = false
-
-[tool.setuptools.dynamic]
-license = "MIT"
-license-files = ["LICEN[CS]E*", "COPYING*", "NOTICE*", "AUTHORS*"]
 
 [tool.devpi.upload]
 formats = "sdist.tgz,bdist_wheel"

--- a/tests/examples/plumbum/pyproject.toml
+++ b/tests/examples/plumbum/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "plumbum"
 description = "Plumbum: shell combinators library"
 authors = [{name = "Tomer Filiba", email = "tomerfiliba@gmail.com"}]
+license = {text = "MIT"}
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: MIT License",
@@ -35,9 +36,9 @@ keywords = [
     "cli",
 ]
 urls = {Homepage = "https://plumbum.readthedocs.io"}
-dynamic = ["license", "version"]
 requires-python = ">=3.6"
 dependencies = ["pywin32;platform_system=='Windows' and platform_python_implementation!=\"PyPy\""]
+dynamic = ["version"]
 
 [project.readme]
 file = "README.rst"
@@ -61,6 +62,7 @@ ssh = ["paramiko"]
 [tool.setuptools]
 platforms = ["POSIX", "Windows"]
 provides = ["plumbum"]
+license-files = ["LICENSE"]
 include-package-data = false
 
 [tool.setuptools.packages.find]
@@ -69,10 +71,6 @@ namespaces = false
 
 [tool.setuptools.package-data]
 "plumbum.cli" = ["i18n/*/LC_MESSAGES/*.mo"]
-
-[tool.setuptools.dynamic]
-license = "MIT"
-license-files = ["LICENSE"]
 
 [tool.coverage.run]
 branch = true

--- a/tests/examples/pyscaffold/pyproject.toml
+++ b/tests/examples/pyscaffold/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "PyScaffold"
 description = "Template tool for putting up the scaffold of a Python project"
 authors = [{name = "Florian Wilhelm", email = "Florian.Wilhelm@gmail.com"}]
+license = {text = "MIT"}
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Topic :: Utilities",
@@ -20,7 +21,6 @@ classifiers = [
     "Operating System :: MacOS",
     "Operating System :: Microsoft :: Windows",
 ]
-dynamic = ["license", "version"]
 requires-python = ">=3.6"
 dependencies = [
     'importlib-metadata; python_version<"3.8"',
@@ -37,6 +37,7 @@ dependencies = [
     # However we specify a higher version so we encourage users to update the
     # version they have installed...
 ]
+dynamic = ["version"]
 
 [project.urls]
 Homepage = "https://github.com/pyscaffold/pyscaffold/"
@@ -113,10 +114,6 @@ platforms = ["any"]
 where = ["src"]
 exclude = ["tests"]
 namespaces = true
-
-[tool.setuptools.dynamic]
-license = "MIT"
-license-files = ["LICEN[CS]E*", "COPYING*", "NOTICE*", "AUTHORS*"]
 
 [tool.pytest.ini_options]
 # Options for pytest:

--- a/tests/examples/setuptools_docs/pyproject.toml
+++ b/tests/examples/setuptools_docs/pyproject.toml
@@ -6,13 +6,14 @@ build-backend = "setuptools.build_meta"
 name = "my_package"
 description = "My package description"
 keywords = ["one", "two"]
+license = {text = "BSD 3-Clause License"}
 classifiers = [
     "Framework :: Django",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.5",
 ]
-dynamic = ["readme", "license", "version"]
+dynamic = ["readme", "version"]
 dependencies = [
     "requests",
     'importlib; python_version == "2.6"',
@@ -54,6 +55,4 @@ fonts = ["data/fonts/*.ttf", "data/fonts/*.otf"]
 
 [tool.setuptools.dynamic]
 readme = {file = ["README.rst", "CHANGELOG.rst", "LICENSE.rst"]}
-license = "BSD 3-Clause License"
-license-files = ["LICEN[CS]E*", "COPYING*", "NOTICE*", "AUTHORS*"]
 version = {attr = "src.VERSION"}

--- a/tests/examples/setuptools_scm/pyproject.toml
+++ b/tests/examples/setuptools_scm/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "setuptools_scm"
 description = "the blessed package to manage your versions by scm tags"
 authors = [{name = "Ronny Pfannschmidt", email = "opensource@ronnypfannschmidt.de"}]
+license = {text = "MIT"}
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
@@ -23,13 +24,13 @@ classifiers = [
     "Topic :: Utilities",
 ]
 urls = {Homepage = "https://github.com/pypa/setuptools_scm/"}
-dynamic = ["license", "version"]
 requires-python = ">=3.6"
 dependencies = [
     "packaging>=20.0",
     "setuptools",
     "tomli>=1.0.0", # keep in sync
 ]
+dynamic = ["version"]
 
 [project.readme]
 file = "README.rst"
@@ -81,12 +82,9 @@ toml = [
 [tool.setuptools]
 package-dir = {"" = "src"}
 zip-safe = true
+license-files = ["LICENSE"]
 include-package-data = false
 
 [tool.setuptools.packages.find]
 where = ["src"]
 namespaces = false
-
-[tool.setuptools.dynamic]
-license = "MIT"
-license-files = ["LICENSE"]

--- a/tests/examples/virtualenv/pyproject.toml
+++ b/tests/examples/virtualenv/pyproject.toml
@@ -7,6 +7,7 @@ name = "virtualenv"
 description = "Virtual Python Environment builder"
 authors = [{name = "Bernat Gabor", email = "gaborjbernat@gmail.com"}]
 maintainers = [{name = "Bernat Gabor", email = "gaborjbernat@gmail.com"}]
+license = {text = "MIT"}
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
@@ -30,7 +31,6 @@ classifiers = [
     "Topic :: Utilities",
 ]
 keywords = ["virtual", "environments", "isolated"]
-dynamic = ["license", "version"]
 requires-python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 dependencies = [
     "backports.entry_points_selectable>=1.0.4",
@@ -42,6 +42,7 @@ dependencies = [
     'importlib-resources>=1.0;python_version<"3.7"',
     "pathlib2>=2.3.3,<3;python_version < '3.4' and sys.platform != 'win32'",
 ]
+dynamic = ["version"]
 
 [project.readme]
 file = "README.md"
@@ -109,6 +110,7 @@ virtualenv = "virtualenv.__main__:run_with_catch"
 package-dir = {"" = "src"}
 zip-safe = true
 platforms = ["any"]
+license-files = ["LICENSE"]
 include-package-data = false
 
 [tool.setuptools.packages.find]
@@ -123,10 +125,6 @@ namespaces = false
 "virtualenv.activation.nushell" = ["*.nu"]
 "virtualenv.activation.powershell" = ["*.ps1"]
 "virtualenv.seed.wheels.embed" = ["*.whl"]
-
-[tool.setuptools.dynamic]
-license = "MIT"
-license-files = ["LICENSE"]
 
 [tool.distutils.sdist]
 formats = "gztar"

--- a/tests/examples/zipp/pyproject.toml
+++ b/tests/examples/zipp/pyproject.toml
@@ -15,9 +15,9 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
 ]
 urls = {Homepage = "https://github.com/jaraco/zipp"}
-dynamic = ["license", "version"]
 requires-python = ">=3.6"
 dependencies = []
+dynamic = ["version"]
 
 [project.optional-dependencies]
 testing = [
@@ -53,6 +53,3 @@ exclude = [
     "tests*",
 ]
 namespaces = true
-
-[tool.setuptools.dynamic]
-license-files = ["LICEN[CS]E*", "COPYING*", "NOTICE*", "AUTHORS*"]

--- a/tests/plugins/test_setuptools_pep621.py
+++ b/tests/plugins/test_setuptools_pep621.py
@@ -261,8 +261,9 @@ license-files = LICENSE.txt
 
 expected_handle_license_files = """\
 [metadata]
-[metadata.license]
-file = "LICENSE.txt"
+
+[options]
+license-files = ["LICENSE.txt"]
 """
 
 
@@ -271,7 +272,8 @@ def test_handle_license_files(plugin, parse, convert):
     doc = plugin.apply_value_processing(doc)
     print(doc)
     print("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@")
-    doc = plugin.handle_license_and_files(doc)
+    doc = plugin.handle_license(doc)
+    doc = plugin.remove_metadata_not_in_pep621(doc)
     print("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@")
     print(doc)
     assert convert(doc).strip() == expected_handle_license_files.strip()
@@ -284,9 +286,8 @@ license-files = LICENSE.txt, NOTICE.txt
 
 expected_handle_multiple_license_files = """\
 [metadata]
-dynamic = ["license"]
 
-["options.dynamic"]
+[options]
 license-files = ["LICENSE.txt", "NOTICE.txt"]
 """
 
@@ -296,7 +297,8 @@ def test_handle_multiple_license_files(plugin, parse, convert):
     doc = plugin.apply_value_processing(doc)
     print(doc)
     print("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@")
-    doc = plugin.handle_license_and_files(doc)
+    doc = plugin.handle_license(doc)
+    doc = plugin.remove_metadata_not_in_pep621(doc)
     print("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@")
     print(doc)
     assert convert(doc).strip() == expected_handle_multiple_license_files.strip()
@@ -309,11 +311,7 @@ license = MPL-2.0
 
 expected_handle_license = """\
 [metadata]
-dynamic = ["license"]
-
-["options.dynamic"]
-license = "MPL-2.0"
-license-files = ["LICEN[CS]E*", "COPYING*", "NOTICE*", "AUTHORS*"]
+license = {text = "MPL-2.0"}
 """
 
 
@@ -322,7 +320,8 @@ def test_handle_license(plugin, parse, convert):
     doc = plugin.apply_value_processing(doc)
     print(doc)
     print("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@")
-    doc = plugin.handle_license_and_files(doc)
+    doc = plugin.handle_license(doc)
+    doc = plugin.remove_metadata_not_in_pep621(doc)
     print("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@")
     print(doc)
     assert convert(doc).strip() == expected_handle_license.strip()
@@ -330,16 +329,15 @@ def test_handle_license(plugin, parse, convert):
 
 example_handle_license_and_files = """\
 [metadata]
-license = MPL-2.0
+license = MPL-2.0  # comment
 license-files = LICENSE.txt
 """
 
 expected_handle_license_and_files = """\
 [metadata]
-dynamic = ["license"]
+license = {text = "MPL-2.0"} # comment
 
-["options.dynamic"]
-license = "MPL-2.0"
+[options]
 license-files = ["LICENSE.txt"]
 """
 
@@ -349,7 +347,8 @@ def test_handle_license_and_files(plugin, parse, convert):
     doc = plugin.apply_value_processing(doc)
     print(doc)
     print("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@")
-    doc = plugin.handle_license_and_files(doc)
+    doc = plugin.handle_license(doc)
+    doc = plugin.remove_metadata_not_in_pep621(doc)
     print("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@")
     print(doc)
     assert convert(doc).strip() == expected_handle_license_and_files.strip()
@@ -606,14 +605,11 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project]
-dynamic = ["license", "version"]
+dynamic = ["version"]
 
 [tool]
 [tool.setuptools]
 include-package-data = false
-
-[tool.setuptools.dynamic]
-license-files = ["LICEN[CS]E*", "COPYING*", "NOTICE*", "AUTHORS*"]
 """
 
 
@@ -647,15 +643,12 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project]
-dynamic = ["license", "version"]
+dynamic = ["version"]
 
 [tool]
 [tool.setuptools]
 data-files = {a = ["b"]}
 include-package-data = false
-
-[tool.setuptools.dynamic]
-license-files = ["LICEN[CS]E*", "COPYING*", "NOTICE*", "AUTHORS*"]
 """
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,8 +21,6 @@ extras =
 # Overwrite dependency just while the latest version is not published:
 # deps =
 #    validate-pyproject @ git+https://github.com/abravalheri/validate-pyproject@main#egg=validate-pyproject
-deps =
-    validate-pyproject @ git+https://github.com/abravalheri/validate-pyproject@remove-license-from-dynamic#egg=validate-pyproject
 commands =
     pytest {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,8 @@ extras =
 # Overwrite dependency just while the latest version is not published:
 # deps =
 #    validate-pyproject @ git+https://github.com/abravalheri/validate-pyproject@main#egg=validate-pyproject
+deps =
+    validate-pyproject @ git+https://github.com/abravalheri/validate-pyproject@remove-license-from-dynamic#egg=validate-pyproject
 commands =
     pytest {posargs}
 


### PR DESCRIPTION
Previously, `ini2toml` was considering that `project.license` and `project.dynamic` were relevant for setting the `License-file` in `PKG-INFO`. As clarified in a [recent discussion](https://discuss.python.org/t/help-testing-experimental-features-in-setuptools/13821/49), that is not the case: `setuptools` can fill `License-file` even when `project.license` is static and `pyproject.toml`' `license.file` is completely unrelated to `setup.cfg`' `license_files`.

When we consider `license` and `license-files` separately, we can simplify the implementation:

- `setup.cfg license` can be converted directly into `pyproject.toml license.text`
- `setup.cfg license-files` can be converted directly into `pyproject.toml tool.setuptools.license-files` (this will be reviewed after the approval of PEP 639 when there will be a standard for that field).

See:
- https://discuss.python.org/t/help-testing-experimental-features-in-setuptools/13821/49
- https://discuss.python.org/t/help-testing-experimental-features-in-setuptools/13821/57