### PR TITLE
CI: Update used actions to v3, test with Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,9 @@ jobs:
     strategy:
       matrix:
         python:
-        - 3.7  # oldest Python supported by PSF
+        - "3.7"  # oldest Python supported by PSF
         - "3.10"  # newest Python that is stable
+        - "3.11-dev"  # current Python beta
         platform:
         - ubuntu-latest
         - macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ jobs:
     outputs:
       wheel-distribution: ${{ steps.wheel-distribution.outputs.path }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with: {fetch-depth: 0}  # deep clone for setuptools-scm
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         with: {python-version: "3.10"}
       - name: Run static analysis and format checkers
         run: pipx run tox -e lint,typecheck
@@ -39,7 +39,7 @@ jobs:
       - name: Store the distribution files for use in other stages
         # `tests` and `publish` will use the same pre-built distributions,
         # so we make sure to release the exact same package that was tested
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: python-distribution-files
           path: dist/
@@ -58,12 +58,12 @@ jobs:
         - windows-latest
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python }}
       - name: Retrieve pre-built distribution files
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with: {name: python-distribution-files, path: dist/}
       - name: Run tests
         run: >-
@@ -95,11 +95,11 @@ jobs:
     if: ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
         with: {python-version: "3.10"}
       - name: Retrieve pre-built distribution files
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with: {name: python-distribution-files, path: dist/}
       - name: Publish Package
         env:


### PR DESCRIPTION
A bit of maintenance on the CI:

- Updates actions/checkout, actions/setup-python and actions/download-artifact to v3
- Run tests also with Python 3.11.

Python 3.11 is now in beta and feature stable. By adding a Python 3.11 test run we can catch errors and bugs before Python 3.11 will become stable.