### PR TITLE
cli: Set up logging at the beginning of execution.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 0.11.4 (dev)
+====================
+
+* Fix logging in case of early errors while loading plugins, :pr:`69`
+
 Version 0.11.3
 ==============
 

--- a/src/ini2toml/cli.py
+++ b/src/ini2toml/cli.py
@@ -168,7 +168,7 @@ def setup_logging(loglevel: int):
 
 
 @contextmanager
-def exceptisons2exit():
+def exceptions2exit():
     try:
         yield
     except Exception as ex:
@@ -177,7 +177,7 @@ def exceptisons2exit():
         raise SystemExit(1)
 
 
-@exceptisons2exit()
+@exceptions2exit()
 def run(args: Sequence[str] = ()):
     """Wrapper allowing :obj:`Translator` to be called in a CLI fashion.
 

--- a/src/ini2toml/cli.py
+++ b/src/ini2toml/cli.py
@@ -129,7 +129,6 @@ def __meta__(
     return meta
 
 
-@critical_logging()
 def parse_args(
     args: Sequence[str],
     profiles: Sequence[Profile],
@@ -189,11 +188,12 @@ def run(args: Sequence[str] = ()):
       args (List[str]): command line parameters as list of strings
           (for example  ``["--verbose", "setup.cfg"]``).
     """
-    args = args or sys.argv[1:]
-    translator = Translator()
-    profiles = list(translator.profiles.values())
-    profile_augmentations = list(translator.augmentations.values())
-    params = parse_args(args, profiles, profile_augmentations)
+    with critical_logging():
+        args = args or sys.argv[1:]
+        translator = Translator()
+        profiles = list(translator.profiles.values())
+        profile_augmentations = list(translator.augmentations.values())
+        params = parse_args(args, profiles, profile_augmentations)
     setup_logging(params.loglevel)
     out = translator.translate(
         params.input_file.read(), params.profile, params.active_augmentations

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -79,9 +79,9 @@ def test_critical_logging_does_nothing_if_no_argv(monkeypatch, caplog):
     assert spy.call_args is None
 
 
-def test_exceptisons2exit():
+def test_exceptions2exit():
     with pytest.raises(SystemExit):
-        with cli.exceptisons2exit():
+        with cli.exceptions2exit():
             raise ValueError
 
 


### PR DESCRIPTION
We can't wait until argument parsing to set up logging because argument parsing is dependent upon profiles loading which is a likely source of errors which would then be suppressed.

For example, I'd added my plugin to `entry_points` but had not added it to `sys.path`, which raised the unclear exception message: `ErrorLoadingPlugin: There was an error loading 'ini2toml_plugin'.` and `-vv` didn't add any more information because logging hadn't been set up according to parameters yet.

<s>Also fixes typo "exceptisons2exit" -> "exceptions2exit".</s>