### PR TITLE
Parse `pytest`'s `filterwarnings` as a line-separated list.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Version 0.11.4 (dev)
 ====================
 
 * Fix logging in case of early errors while loading plugins, :pr:`69`
+* ``pytest`` plugin:
+   * Fix parsing of ``filterwarnings``, issue:`74`
 
 Version 0.11.3
 ==============

--- a/src/ini2toml/plugins/pytest.py
+++ b/src/ini2toml/plugins/pytest.py
@@ -9,10 +9,10 @@ from ..types import IntermediateRepr, Translator
 
 R = TypeVar("R", bound=IntermediateRepr)
 
-list_with_space = partial(split_list, sep=" ")
-split_markers = partial(split_list, sep="\n")
+split_spaces = partial(split_list, sep=" ")
+split_lines = partial(split_list, sep="\n")
 # ^ most of the list values in pytest use whitespace separators,
-#   but markers are a special case, since they can define a help text
+#   but markers/filterwarnings are a special case.
 
 
 def activate(translator: Translator):
@@ -25,8 +25,11 @@ def activate(translator: Translator):
 class Pytest:
     """Convert settings to 'pyproject.toml' ('ini_options' table)"""
 
-    LIST_VALUES = (
+    LINE_SEPARATED_LIST_VALUES = (
+        "markers",
         "filterwarnings",
+    )
+    SPACE_LIST_VALUES = (
         "norecursedirs",
         "python_classes",
         "python_files",
@@ -56,9 +59,9 @@ class Pytest:
         for field in section:
             if field in self.DONT_TOUCH:
                 continue
-            if field == "markers":
-                section[field] = split_markers(section[field])
-            elif field in self.LIST_VALUES:
-                section[field] = list_with_space(section[field])
+            if field in self.LINE_SEPARATED_LIST_VALUES:
+                section[field] = split_lines(section[field])
+            elif field in self.SPACE_LIST_VALUES:
+                section[field] = split_spaces(section[field])
             else:
                 section[field] = coerce_scalar(section[field])

--- a/src/ini2toml/plugins/pytest.py
+++ b/src/ini2toml/plugins/pytest.py
@@ -29,7 +29,7 @@ class Pytest:
         "markers",
         "filterwarnings",
     )
-    SPACE_LIST_VALUES = (
+    SPACE_SEPARATED_LIST_VALUES = (
         "norecursedirs",
         "python_classes",
         "python_files",
@@ -61,7 +61,7 @@ class Pytest:
                 continue
             if field in self.LINE_SEPARATED_LIST_VALUES:
                 section[field] = split_lines(section[field])
-            elif field in self.SPACE_LIST_VALUES:
+            elif field in self.SPACE_SEPARATED_LIST_VALUES:
                 section[field] = split_spaces(section[field])
             else:
                 section[field] = coerce_scalar(section[field])

--- a/tests/plugins/test_pytest.py
+++ b/tests/plugins/test_pytest.py
@@ -19,7 +19,10 @@ def test_pytest():
         dist
         build
         .tox
-    """
+    filterwarnings=
+        error
+        ignore:Please use `dok_matrix` from the `scipy\\.sparse` namespace, the `scipy\\.sparse\\.dok` namespace is deprecated.:DeprecationWarning
+    """  # noqa
     expected = """\
     [pytest]
     [pytest.ini_options]
@@ -32,6 +35,10 @@ def test_pytest():
         "dist", 
         "build", 
         ".tox", 
+    ]
+    filterwarnings = [
+        "error",
+        'ignore:Please use `dok_matrix` from the `scipy\\.sparse` namespace, the `scipy\\.sparse\\.dok` namespace is deprecated.:DeprecationWarning',
     ]
     """  # noqa
     for convert in (lite_toml.convert, full_toml.convert):


### PR DESCRIPTION
Fixes #74.