### PR TITLE
Add hint to the user, when tools that don't support `pyproject.toml` are used (e.g. `pytest`)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Version 0.11.4 (dev)
 ====================
 
 * Fix logging in case of early errors while loading plugins, :pr:`69`
+* Log warning if ``flake8`` and ``devpi`` sections are translation,
+  prompting the user to review the output, :issue:`72`
 * ``pytest`` plugin:
    * Fix parsing of ``filterwarnings``, issue:`74`
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -104,6 +104,7 @@ ini2toml.processing =
     pytest = ini2toml.plugins.pytest:activate
     mypy = ini2toml.plugins.mypy:activate
     independent_tasks = ini2toml.plugins.profile_independent_tasks:activate
+    toml_incompatibilities = ini2toml.plugins.toml_incompatibilities:activate
 
 [tool:pytest]
 # Specify command line options as you would do when invoking pytest directly.

--- a/src/ini2toml/plugins/toml_incompatibilities.py
+++ b/src/ini2toml/plugins/toml_incompatibilities.py
@@ -1,0 +1,52 @@
+import warnings
+from inspect import cleandoc
+from typing import List, TypeVar
+
+from ..types import IntermediateRepr, Translator
+
+R = TypeVar("R", bound=IntermediateRepr)
+
+
+_FLAKE8_SECTIONS = ["flake8", "flake8:local-plugins"]
+
+_KNOWN_INCOMPATIBILITIES = {
+    "setup.cfg": ["flake8", "flake8:local-plugins", "devpi:upload"],
+    ".flake8": _FLAKE8_SECTIONS,
+}
+
+
+def activate(translator: Translator):
+    for name, sections in _KNOWN_INCOMPATIBILITIES.items():
+        fn = StripSections(name, sections)
+        translator[name].intermediate_processors.insert(0, fn)
+
+
+class StripSections:
+    """Remove well-know incompatible sections."""
+
+    def __init__(self, profile: str, sections: List[str]):
+        self._profile = profile
+        self._sections = sections
+
+    def __call__(self, cfg: R) -> R:
+        invalid = [section for section in self._sections if section in cfg]
+        if invalid:
+            sections = ", ".join(repr(x) for x in invalid)
+            ConfigurationNotSupported.emit(self._profile, sections)
+        for section in invalid:
+            del cfg[section]
+        return cfg
+
+
+class ConfigurationNotSupported(UserWarning):
+    """
+    Ignoring sections {sections} ({profile!r}).
+
+    It might be the case TOML files are not supported by the relevant tools,
+    or that 'ini2toml' just lacks a plugin for this kind of configuration.
+    """
+
+    @classmethod
+    def emit(cls, profile, sections):
+        msg = cleandoc(cls.__doc__.format(profile=profile, sections=sections))
+        warnings.warn(msg, cls, stacklevel=6)

--- a/src/ini2toml/plugins/toml_incompatibilities.py
+++ b/src/ini2toml/plugins/toml_incompatibilities.py
@@ -1,4 +1,4 @@
-import warnings
+import logging
 from inspect import cleandoc
 from typing import List, TypeVar
 
@@ -6,22 +6,23 @@ from ..types import IntermediateRepr, Translator
 
 R = TypeVar("R", bound=IntermediateRepr)
 
+_logger = logging.getLogger(__package__)
 
-_FLAKE8_SECTIONS = ["flake8", "flake8:local-plugins"]
+_FLAKE8_SECTIONS = ["flake8", "flake8-rst", "flake8:local-plugins"]
 
 _KNOWN_INCOMPATIBILITIES = {
-    "setup.cfg": ["flake8", "flake8:local-plugins", "devpi:upload"],
+    "setup.cfg": [*_FLAKE8_SECTIONS, "devpi:upload"],
     ".flake8": _FLAKE8_SECTIONS,
 }
 
 
 def activate(translator: Translator):
     for name, sections in _KNOWN_INCOMPATIBILITIES.items():
-        fn = StripSections(name, sections)
+        fn = ReportIncompatibleSections(name, sections)
         translator[name].intermediate_processors.insert(0, fn)
 
 
-class StripSections:
+class ReportIncompatibleSections:
     """Remove well-know incompatible sections."""
 
     def __init__(self, profile: str, sections: List[str]):
@@ -32,21 +33,17 @@ class StripSections:
         invalid = [section for section in self._sections if section in cfg]
         if invalid:
             sections = ", ".join(repr(x) for x in invalid)
-            ConfigurationNotSupported.emit(self._profile, sections)
-        for section in invalid:
-            del cfg[section]
+            _logger.warning(_warning_text(self._profile, sections))
         return cfg
 
 
-class ConfigurationNotSupported(UserWarning):
-    """
-    Ignoring sections {sections} ({profile!r}).
+def _warning_text(profile: str, sections: str) -> str:
+    msg = f"""
+    Sections {sections} ({profile!r}) may be problematic.
 
     It might be the case TOML files are not supported by the relevant tools,
     or that 'ini2toml' just lacks a plugin for this kind of configuration.
-    """
 
-    @classmethod
-    def emit(cls, profile, sections):
-        msg = cleandoc(cls.__doc__.format(profile=profile, sections=sections))
-        warnings.warn(msg, cls, stacklevel=6)
+    Please review the generated output and remove these sections if necessary.
+    """
+    return cleandoc(msg) + "\n"

--- a/tests/plugins/test_toml_incompatibilities.py
+++ b/tests/plugins/test_toml_incompatibilities.py
@@ -1,0 +1,50 @@
+import logging
+
+import pytest
+
+from ini2toml.drivers import configparser, configupdater
+from ini2toml.plugins import toml_incompatibilities as plugin
+from ini2toml.translator import Translator
+
+EXAMPLE_FLAKE8 = """
+[flake8]
+# Some sane defaults for the code style checker flake8
+# black compatibility
+max_line_length = 88
+# E203 and W503 have edge cases handled by black
+extend_ignore = E203, W503
+exclude =
+    src/pyscaffold/contrib
+    .tox
+    build
+    dist
+    .eggs
+    docs/conf.py
+"""
+
+EXAMPLE_DEVPI = """
+[devpi:upload]
+# Options for the devpi: PyPI server and packaging tool
+# VCS export must be deactivated since we are using setuptools-scm
+no_vcs = 1
+formats = bdist_wheel
+"""
+
+EXAMPLES = {
+    "flake8": (".flake8", "flake8", EXAMPLE_FLAKE8),
+    "flake8-setup.cfg": ("setup.cfg", "flake8", EXAMPLE_FLAKE8),
+    "devpi-setup.cfg": ("setup.cfg", "devpi:upload", EXAMPLE_DEVPI),
+}
+
+
+@pytest.mark.parametrize("example", EXAMPLES.keys())
+@pytest.mark.parametrize("convert", (configparser.parse, configupdater.parse))
+def test_log_warnings(example, convert, caplog):
+    """ini2toml should display a warning via the logging system"""
+    profile, section, content = EXAMPLES[example]
+    translator = Translator(plugins=[plugin.activate], ini_loads_fn=convert)
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        translator.translate(content, profile)
+    expected = plugin._warning_text(profile, repr(section))
+    assert expected in caplog.text


### PR DESCRIPTION
The way `ini2toml` works is by translating the `.ini` "AST" into a `.toml` "AST". The plugins are just a way of correcting things that use some forms of semantics on top of the `.ini`/`.toml` syntax.

This means that anything in the original file will end up translated: the translation is general but the "correction" is ad-hoc. As a consequence, we cannot "warn" or ignore `.ini` sections that are unknown to the plugins.

Adding ad-hoc `logging.warning` messages was the best way I found to hint to the user that these sections might not work the way they expect. I did not go for `warnings.warn` to not bother downstream usages (as a library).

Closes #72.

---

By the way, there are tools out there that "wrap" tools that don't support `pyproject.toml`, e.g.: `pyproject-flake8`, `flake8-pyproject`. So in the end users may not be really wanting to ignore those sections.