### PR TITLE
Add support for `file:` directive in `install_requires`, `extras_require`

### DIFF
--- a/tests/examples/dynamic_extras/pyproject.toml
+++ b/tests/examples/dynamic_extras/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools>=61.2"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "hello"
+version = "42"
+dynamic = ["dependencies", "optional-dependencies"]
+
+[tool.setuptools]
+include-package-data = false
+
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements.txt"]}
+
+[tool.setuptools.dynamic.optional-dependencies]
+dev = {file = ["dev-requirements.txt"]}

--- a/tests/examples/dynamic_extras/setup.cfg
+++ b/tests/examples/dynamic_extras/setup.cfg
@@ -1,0 +1,9 @@
+[metadata]
+name = hello
+version = 42
+
+[options]
+install_requires = file: requirements.txt
+
+[options.extras_require]
+dev = file: dev-requirements.txt

--- a/tests/examples/dynamic_extras_mixed/pyproject.toml
+++ b/tests/examples/dynamic_extras_mixed/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=61.2"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "hello"
+version = "42"
+dynamic = ["dependencies", "optional-dependencies"]
+
+[tool.setuptools]
+include-package-data = false
+
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements.txt"]}
+
+[tool.setuptools.dynamic.optional-dependencies]
+dev = {file = ["dev-requirements.txt"]}
+other = [
+    "platformdirs",
+    "rich",
+]

--- a/tests/examples/dynamic_extras_mixed/setup.cfg
+++ b/tests/examples/dynamic_extras_mixed/setup.cfg
@@ -1,0 +1,12 @@
+[metadata]
+name = hello
+version = 42
+
+[options]
+install_requires = file: requirements.txt
+
+[options.extras_require]
+dev = file: dev-requirements.txt
+other =
+    platformdirs
+    rich


### PR DESCRIPTION
Please note that for the time being `setuptools` does not support mixing dynamic and non-dynamic `extras_require`.

`ini2toml` will do the conversion but it will show the limitation in the logging.

We probably need to implement that in setuptools.

Closes #71