### PR TITLE
Fix conflict between `setuptools` plugin and `isort` plugin, when isort defines `isort.setuptools_commands.ISortCommand`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Version 0.13.1 (dev)
+====================
+
+* Fix errors when ``isort`` is installed in the same environment as
+  ``ini2toml``.
+
 Version 0.13
 ============
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,6 +77,7 @@ experimental =
 
 # Add here test requirements (semicolon/line-separated)
 testing =
+    isort
     setuptools
     tomli
     pytest

--- a/src/ini2toml/base_translator.py
+++ b/src/ini2toml/base_translator.py
@@ -163,5 +163,6 @@ def _deduplicate_plugins(plugins: Sequence[types.Plugin]) -> List[types.Plugin]:
 
 def _plugin_name(plugin: types.Plugin) -> str:
     mod = inspect.getmodule(plugin)
+    modname = getattr(mod, "__name__", str(mod))
     name = getattr(plugin, "__qualname__", getattr(plugin, "__name__", "**plugin**"))
-    return f"{mod}:{name}"
+    return f"{modname}:{name}"

--- a/src/ini2toml/plugins/best_effort.py
+++ b/src/ini2toml/plugins/best_effort.py
@@ -50,6 +50,8 @@ class BestEffort:
     def apply_best_effort(self, container: M, field: str, value: str):
         if isinstance(field, HiddenKey):
             return
+        if not isinstance(value, str):
+            return
         lines = value.splitlines()
         if len(lines) > 1:
             if self.key_sep in value:

--- a/src/ini2toml/plugins/coverage.py
+++ b/src/ini2toml/plugins/coverage.py
@@ -1,6 +1,6 @@
 # based on https://coverage.readthedocs.io/en/stable/config.html
 from collections.abc import MutableMapping
-from functools import partial
+from functools import partial, update_wrapper
 from typing import TypeVar
 
 from ..transformations import coerce_scalar, split_list
@@ -15,6 +15,7 @@ def activate(translator: Translator):
     profile = translator[".coveragerc"]
 
     fn = partial(plugin.process_values, prefix="")
+    update_wrapper(fn, plugin.process_values)
     profile.intermediate_processors.append(fn)
     profile.help_text = plugin.__doc__ or ""
 

--- a/src/ini2toml/plugins/isort.py
+++ b/src/ini2toml/plugins/isort.py
@@ -1,6 +1,6 @@
 # https://pycqa.github.io/isort/docs/configuration/config_files
 from collections.abc import Mapping, MutableMapping
-from functools import partial
+from functools import partial, update_wrapper
 from typing import Set, TypeVar
 
 from ..transformations import coerce_scalar, kebab_case, split_list
@@ -14,6 +14,7 @@ def activate(translator: Translator):
     plugin = ISort()
     profile = translator[".isort.cfg"]
     fn = partial(plugin.process_values, section_name="settings")
+    update_wrapper(fn, plugin.process_values)
     profile.intermediate_processors.append(fn)
     profile.help_text = plugin.__doc__ or ""
 

--- a/src/ini2toml/plugins/setuptools_pep621.py
+++ b/src/ini2toml/plugins/setuptools_pep621.py
@@ -86,6 +86,9 @@ COMMAND_SECTIONS = (
     "bdist_wheel",
     *getattr(distutils_commands, "__all__", []),
 )
+SKIP_COMMAND_SECTIONS = {
+    "isort",
+}
 
 
 def activate(translator: Translator):
@@ -595,7 +598,7 @@ class SetuptoolsPEP621:
         tool-specific sub-table
         """
         sections = list(doc.keys())
-        commands = _distutils_commands()
+        commands = _distutils_commands() - SKIP_COMMAND_SECTIONS
         for k in sections:
             if isinstance(k, str) and k in commands:
                 section = self._be.apply_best_effort_to_section(doc[k])


### PR DESCRIPTION
Fix #80.

It seems that the problem appears only if `isort` is installed in the same virtualenv.
`isort` defines a setuptools command `isort.setuptools_commands.ISortCommand`, which is probably causing a clash between the setuptools transformer and the isort transformer.