### PR TITLE
Fix `ValueError` for `setup.cfg` with both explicit `[options] packages = ...` and unused `[options.packages.find]`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+Development Version
+===================
+* ``setuptools`` plugin:
+  * Fix ``ValueError`` when ``setup.cfg`` contains ``[options.packages.find]``
+    but also lists ``[options] packages = ...`` explicitly as a list of package
+    names, :issue:`93`
+
+
 Version 0.13
 ============
 


### PR DESCRIPTION
Fix #93 