### PR TITLE
Improve determinism of flavours for API.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,11 +4,13 @@ Changelog
 
 Development Version
 ===================
+
+* Introduce ``LiteTranslator`` and ``FullTranslator`` as
+  convenience classes for more deterministic behaviour.
 * ``setuptools`` plugin:
   * Fix ``ValueError`` when ``setup.cfg`` contains ``[options.packages.find]``
     but also lists ``[options] packages = ...`` explicitly as a list of package
     names, :issue:`93`
-
 
 Version 0.13
 ============

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Development Version
 ===================
 
 * Introduce ``LiteTranslator`` and ``FullTranslator`` as
-  convenience classes for more deterministic behaviour.
+  convenience classes for more deterministic behaviour, :pr:`95`.
 * ``setuptools`` plugin:
   * Fix ``ValueError`` when ``setup.cfg`` contains ``[options.packages.find]``
     but also lists ``[options] packages = ...`` explicitly as a list of package

--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,12 @@ You can also use ``ini2toml`` in your Python scripts or projects:
 To do so, don't forget to add it to your `virtual environment`_ or specify it as a
 `project dependency`_.
 
+Note that the class ``Translator`` will try to guess which flavour to use based
+on the available installed dependencies. If you need something more
+deterministic, consider using ``LiteTranslator`` and ``FullTranslator``,
+or explicitly specifying the ``ini_loads_fn`` and ``toml_dumps_fn`` keyword
+arguments in the constructor.
+
 More details about ``ini2toml`` and its Python API can be found in `our docs`_.
 
 

--- a/src/ini2toml/api.py
+++ b/src/ini2toml/api.py
@@ -21,6 +21,14 @@ Plugin authors can also rely on the functions exported by
 
 from . import errors, transformations, types
 from .base_translator import BaseTranslator
-from .translator import Translator
+from .translator import FullTranslator, LiteTranslator, Translator
 
-__all__ = ["BaseTranslator", "Translator", "errors", "types", "transformations"]
+__all__ = [
+    "BaseTranslator",
+    "FullTranslator",
+    "LiteTranslator",
+    "Translator",
+    "errors",
+    "types",
+    "transformations",
+]

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -9,7 +9,7 @@ from validate_pyproject.errors import ValidationError
 
 from ini2toml import cli
 from ini2toml.drivers import configparser, full_toml, lite_toml
-from ini2toml.translator import Translator
+from ini2toml.translator import FullTranslator, LiteTranslator
 
 
 def examples():
@@ -39,7 +39,7 @@ def validate():
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 @pytest.mark.parametrize(("original", "expected"), list(examples()))
 def test_examples_api(original, expected, validate):
-    translator = Translator()
+    translator = FullTranslator()
     available_profiles = list(translator.profiles.keys())
     profile = cli.guess_profile(None, original, available_profiles)
     orig = Path(original)
@@ -71,7 +71,7 @@ INLINE_COMMENT = re.compile(r'#\s[^\n"]*$', re.M)
 @pytest.mark.parametrize(("original", "expected"), list(examples()))
 def test_examples_api_lite(original, expected, validate):
     opts = {"ini_loads_fn": configparser.parse, "toml_dumps_fn": lite_toml.convert}
-    translator = Translator(**opts)
+    translator = LiteTranslator(**opts)
     available_profiles = list(translator.profiles.keys())
     profile = cli.guess_profile(None, original, available_profiles)
     # We cannot compare "flake8" sections (currently not handled)


### PR DESCRIPTION
Introduce ``LiteTranslator`` and ``FullTranslator`` as convenience classes for more deterministic behaviour.

Closes #96.
