### PR TITLE
Remove experimental feature for automatic formatting

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+Version 0.16
+============
+
+* Removed experimental auto-formatting feature, :pr:`108`.
+  This includes removing the ``experimental`` extra group for optional dependencies.
+  Users that are interested in auto-formatting the output are suggested to run
+  ``pyproject-fmt`` as an additional step, after ``ini2toml``.
+
 Version 0.15
 ============
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,9 +40,6 @@ all = [
     "tomlkit>=0.10.0,<2",
     "tomli-w>=0.4.0,<2",
 ]
-experimental = [
-    "pyproject-fmt>=0.4.0,<2"
-]
 testing = [
     "isort",
     "setuptools",

--- a/src/ini2toml/cli.py
+++ b/src/ini2toml/cli.py
@@ -83,31 +83,6 @@ META: Dict[str, dict] = {
     ),
 }
 
-try:
-    import pyproject_fmt  # noqa
-
-    META["auto_format"] = dict(
-        flags=("-F", "--auto-format"),
-        action="store_true",
-        help="**EXPERIMENTAL** - format output with `pyproject-fmt`\n"
-        "(note that auto-formatting is intrusive and may cause loss of comments).",
-    )
-
-    def apply_auto_formatting(text: str) -> str:
-        try:
-            from pyproject_fmt import Config, format_pyproject
-
-            return format_pyproject(Config(Path("pyproject.toml"), text))
-        except Exception as ex:  # pragma: no cover
-            _logger.debug(f"pyproject-fmt failed: {ex}", exc_info=True)
-            _logger.warning("Auto-formatting failed, falling back to original text")
-            return text
-
-except ImportError:  # pragma: no cover
-
-    def apply_auto_formatting(text: str) -> str:
-        return text
-
 
 def __meta__(
     profiles: Sequence[Profile], augmentations: Sequence[ProfileAugmentation]
@@ -200,8 +175,6 @@ def run(args: Sequence[str] = ()):
     out = translator.translate(
         params.input_file.read(), params.profile, params.active_augmentations
     )
-    if getattr(params, "auto_format", False):
-        out = apply_auto_formatting(out)
     params.output_file.write(out)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,5 @@
 import logging
 import sys
-from inspect import cleandoc
 from unittest.mock import MagicMock
 
 import pytest
@@ -121,42 +120,3 @@ def test_help(capsys):
     expected = " ".join(x.strip() for x in expected_profile_desc.splitlines())
     print(out)
     assert expected in text
-
-
-@pytest.mark.skipif(
-    sys.version_info < (3, 7),
-    reason="pyproject-fmt is only available on Python 3.7+",
-)
-def test_auto_formatting(tmp_path, capsys):
-    setupcfg = """
-    [metadata]
-    version = 42
-    name = myproj
-    """
-    normal_output = """
-    requires = ["setuptools>=61.2"]
-    """
-    expected = """
-    requires = [
-      "setuptools>=61.2",
-    ]
-    """
-
-    # Check if the underlying function works
-    formatted = cli.apply_auto_formatting(cleandoc(expected))
-    assert formatted.strip() == cleandoc(expected).strip()
-
-    (tmp_path / "setup.cfg").write_text(cleandoc(setupcfg), encoding="utf-8")
-    assert (tmp_path / "setup.cfg").exists()
-
-    # Check the output when formatting in off
-    cli.run([str(tmp_path / "setup.cfg")])
-    out, _ = capsys.readouterr()
-    assert cleandoc(normal_output) in out
-    assert cleandoc(expected) not in out
-
-    # Check the output when formatting in on
-    cli.run(["-F", str(tmp_path / "setup.cfg")])
-    out, _ = capsys.readouterr()
-    assert cleandoc(normal_output) not in out
-    assert cleandoc(expected) in out


### PR DESCRIPTION
Due to changes in `pyprojec-fmt` it becomes harder to maintain the feature. So I am opting for removal.
See discussion in https://github.com/abravalheri/ini2toml/issues/103#issuecomment-2112479286.