### PR TITLE
pre-commit autoupdate and update to Py3.13

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -92,8 +92,7 @@ linux_task:
     - name: test (Linux - 3.12)
       container: {image: "python:3.12-bookworm"}
     - name: test (Linux - 3.13)
-      container: {image: "python:3.13-rc-bookworm"}
-      allow_failures: true  # RC
+      container: {image: "python:3.13-bookworm"}
   install_script:
     - python -m pip install --upgrade pip tox pipx
   <<: *test-template

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,11 @@ jobs:
       - uses: actions/checkout@v3
         with: {fetch-depth: 0}  # deep clone for setuptools-scm
       - uses: actions/setup-python@v4
-        with: {python-version: "3.10"}
+        with: {python-version: "3.12"}
       - name: Run static analysis and format checkers
-        run: pipx run --python python3.10 tox -e lint,typecheck
+        run: pipx run --python python3.12 tox -e lint,typecheck
       - name: Build package distribution files
-        run: pipx run --python python3.10 tox -e clean,build
+        run: pipx run --python python3.12 tox -e clean,build
       - name: Record the path of wheel distribution
         id: wheel-distribution
         run: echo "path=$(ls dist/*.whl)" >> $GITHUB_OUTPUT
@@ -50,8 +50,8 @@ jobs:
     strategy:
       matrix:
         python:
-        - "3.7"  # oldest Python supported by PSF
-        - "3.11"  # newest Python that is stable
+        - "3.9"  # oldest Python supported by PSF
+        - "3.13"  # newest Python that is stable
         platform:
         - ubuntu-latest
         - macos-latest
@@ -97,7 +97,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
-        with: {python-version: "3.10"}
+        with: {python-version: "3.12"}
       - name: Retrieve pre-built distribution files
         uses: actions/download-artifact@v3
         with: {name: python-distribution-files, path: dist/}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: '^docs/conf.py'
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.6.0
+  rev: v5.0.0
   hooks:
   - id: trailing-whitespace
     exclude: 'test_(.*)\.py$'
@@ -21,7 +21,7 @@ repos:
     args: ['--fix=lf']
 
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.17.0
+  rev: v3.19.0
   hooks:
   - id: pyupgrade
     args: [--py38-plus]
@@ -42,13 +42,13 @@ repos:
   - id: isort
 
 - repo: https://github.com/psf/black-pre-commit-mirror
-  rev: 24.4.2
+  rev: 24.10.0
   hooks:
     - id: black
       language_version: python3
 
 - repo: https://github.com/asottile/blacken-docs
-  rev: 1.18.0
+  rev: 1.19.1
   hooks:
   - id: blacken-docs
     additional_dependencies: [black]
@@ -57,7 +57,7 @@ repos:
   rev: v2.3.0
   hooks:
   - id: codespell
-    args: [-w]
+    args: [--write-changes]
     additional_dependencies: ["tomli; python_version<'3.11'"]
 
 - repo: https://github.com/PyCQA/flake8
@@ -65,3 +65,8 @@ repos:
   hooks:
   - id: flake8
     additional_dependencies: [flake8-bugbear>=23.2.13]
+
+- repo: https://github.com/abravalheri/validate-pyproject
+  rev: v0.23
+  hooks:
+  - id: validate-pyproject

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 dependencies = [
     "packaging>=20.7",
-    "setuptools>=60",  # local setuptools._distutils is the default
+    "setuptools>=64",  # local setuptools._distutils is the default
 ]
 dynamic = ["version"]
 

--- a/src/ini2toml/plugins/setuptools_pep621.py
+++ b/src/ini2toml/plugins/setuptools_pep621.py
@@ -188,7 +188,6 @@ class SetuptoolsPEP621:
             ),
             ("options.packages.find", "include"): split_list_comma,
             ("options.packages.find", "exclude"): split_list_comma,
-            ("options.packages.find", "exclude"): split_list_comma,
         }
         # See also dependent_processing_rules
 


### PR DESCRIPTION
Python 3.9 thru 3.13.
```diff
-        - "3.7"  # oldest Python supported by PSF
-        - "3.11"  # newest Python that is stable
+        - "3.9"  # oldest Python supported by PSF
+        - "3.13"  # newest Python that is stable
```
Also,
Keep GitHub Actions up to date with GitHub's Dependabot dependabot.yml
* [Keeping your actions up to date with Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot)
* [Configuration options for the dependabot.yml file - package-ecosystem](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem)