### PR TITLE
pre-commit autoupdate 2025-04-01

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: '^docs/conf.py'
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.6.0
+  rev: v5.0.0
   hooks:
   - id: trailing-whitespace
     exclude: 'test_(.*)\.py$'
@@ -21,7 +21,7 @@ repos:
     args: ['--fix=lf']
 
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.17.0
+  rev: v3.19.1
   hooks:
   - id: pyupgrade
     args: [--py38-plus]
@@ -37,31 +37,31 @@ repos:
     ]
 
 - repo: https://github.com/PyCQA/isort
-  rev: 5.13.2
+  rev: 6.0.1
   hooks:
   - id: isort
 
 - repo: https://github.com/psf/black-pre-commit-mirror
-  rev: 24.4.2
+  rev: 25.1.0
   hooks:
     - id: black
       language_version: python3
 
 - repo: https://github.com/asottile/blacken-docs
-  rev: 1.18.0
+  rev: 1.19.1
   hooks:
   - id: blacken-docs
     additional_dependencies: [black]
 
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.3.0
+  rev: v2.4.1
   hooks:
   - id: codespell
     args: [-w]
     additional_dependencies: ["tomli; python_version<'3.11'"]
 
 - repo: https://github.com/PyCQA/flake8
-  rev: 7.1.1
+  rev: 7.2.0
   hooks:
   - id: flake8
     additional_dependencies: [flake8-bugbear>=23.2.13]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
   rev: v2.4.1
   hooks:
   - id: codespell
-    args: [-w]
+    args: [--write-changes]
     additional_dependencies: ["tomli; python_version<'3.11'"]
 
 - repo: https://github.com/PyCQA/flake8
@@ -65,3 +65,8 @@ repos:
   hooks:
   - id: flake8
     additional_dependencies: [flake8-bugbear>=23.2.13]
+
+- repo: https://github.com/abravalheri/validate-pyproject
+  rev: v0.24.1
+  hooks:
+  - id: validate-pyproject

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,10 @@
 """
-    Dummy conftest.py for ini2toml.
+Dummy conftest.py for ini2toml.
 
-    If you don't know what this is for, just leave it empty.
-    Read more about conftest.py under:
-    - https://docs.pytest.org/en/stable/fixture.html
-    - https://docs.pytest.org/en/stable/writing_plugins.html
+If you don't know what this is for, just leave it empty.
+Read more about conftest.py under:
+- https://docs.pytest.org/en/stable/fixture.html
+- https://docs.pytest.org/en/stable/writing_plugins.html
 """
 
 # import pytest


### PR DESCRIPTION
Like #113 but with five dedentations so the tests pass.
* #113 

% `pre-commit autoupdate`
[https://github.com/pre-commit/pre-commit-hooks] updating v4.6.0 -> v5.0.0
[https://github.com/asottile/pyupgrade] updating v3.17.0 -> v3.19.1
[https://github.com/PyCQA/autoflake] already up to date!
[https://github.com/PyCQA/isort] updating 5.13.2 -> 6.0.1
[https://github.com/psf/black-pre-commit-mirror] updating 24.4.2 -> 25.1.0
[https://github.com/asottile/blacken-docs] updating 1.18.0 -> 1.19.1
[https://github.com/codespell-project/codespell] updating v2.3.0 -> v2.4.1
[https://github.com/PyCQA/flake8] updating 7.1.1 -> 7.2.0
% `pre-commit run --all-files`
