### PR TITLE
Use as_string() to get the value

### DIFF
--- a/src/ini2toml/drivers/full_toml.py
+++ b/src/ini2toml/drivers/full_toml.py
@@ -205,7 +205,7 @@ def _convert_irepr_to_toml(irepr: IntermediateRepr, out: T) -> T:
             if len(rest) == 1:
                 nested_key = rest[0]
                 collapsed_value = collapse(value)
-                collapsed_str = f"{nested_key} = {dumps(collapsed_value)}"
+                collapsed_str = f"{nested_key} = {collapsed_value.as_string()}"
                 simplified_str = collapsed_str.replace("= {}", "").replace("= []", "")
                 # Force inline table for the simplest cases
                 if (


### PR DESCRIPTION
tomlkit 0.15.0 has changed the behavior of dumps() to throw an exception of things that aren't a container, so switch to using as_string() instead. This should work with both 0.14.0 and 0.15.0.

Fixes #131